### PR TITLE
Add script to wait for postgres

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-POSTGRES_DB=postgres
+POSTGRES_DB=chimesdb
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_HOST=db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,18 @@
 services:
   db:
     image: postgres
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - pgdata:/var/lib/postgresql/data
   api:
     build: .
+    restart: always
     command: >
-      sh -c "python manage.py migrate &&
+      sh -c "python wait_for_postgres.py &&
+             python manage.py migrate &&
              python manage.py runserver 0.0.0.0:8000"
     volumes:
       - .:/code

--- a/wait_for_postgres.py
+++ b/wait_for_postgres.py
@@ -1,0 +1,45 @@
+import logging
+import os
+from time import sleep, time
+
+import dotenv
+import psycopg2
+
+dotenv.read_dotenv()
+check_timeout = os.getenv("POSTGRES_CHECK_TIMEOUT", 30)
+check_interval = os.getenv("POSTGRES_CHECK_INTERVAL", 1)
+interval_unit = "second" if check_interval == 1 else "seconds"
+config = {
+    "dbname": os.getenv("POSTGRES_DB"),
+    "user": os.getenv("POSTGRES_USER"),
+    "password": os.getenv("POSTGRES_PASSWORD"),
+    "host": os.getenv("POSTGRES_HOST"),
+    "port": os.getenv("POSTGRES_PORT"),
+}
+
+start_time = time()
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler())
+
+
+def pg_isready(host, user, password, dbname, port):
+    while time() - start_time < check_timeout:
+        try:
+            conn = psycopg2.connect(
+                dbname=dbname, user=user, password=password, host=host, port=port
+            )
+            logger.info("Postgres is ready!")
+            conn.close()
+            return True
+        except psycopg2.OperationalError:
+            logger.info(
+                f"Postgres isn't ready. Waiting for {check_interval} {interval_unit}..."
+            )
+            sleep(check_interval)
+
+    logger.error(f"We could not connect to Postgres within {check_timeout} seconds.")
+    return False
+
+
+pg_isready(**config)


### PR DESCRIPTION
This PR adds a script that forces the main api container to wait for the database to accept connections before starting the server.